### PR TITLE
Added LiquityLoans.com (US hosted) front-end

### DIFF
--- a/frontends/liquityloans.com.md
+++ b/frontends/liquityloans.com.md
@@ -1,0 +1,7 @@
+## LiquityLoans.com
+- Website URL: https://liquityloans.com/
+- Date launched: 4/28/2021
+- Company name (if applicable): Emerge Interactive (https://www.emergeinteractive.com/) 
+- Contact (email, Discord, etc.): julian@emergeinteractive.com, julp#6730, Telegram @julianpscheid
+- Kickback Rate: 99.5%
+- Product Description: LiquityLoans.com is based in the U.S. and provides detailed tutorials and FAQs for users who are newer to crypto lending.


### PR DESCRIPTION
LiquityLoans.com is based in the U.S. and provides detailed tutorials and FAQs for users who are newer to crypto lending.