### PR TITLE
Add new frontend: Liquity@Crust

### DIFF
--- a/frontends/liquity_crust.md
+++ b/frontends/liquity_crust.md
@@ -1,0 +1,7 @@
+## Liquity@Crust
+- Website URL: https://ipfs.io/ipfs/QmUHwUh4zyahWknJaqGegaQzK76dL6pPTB1Fa2T1adpkEj/
+- Date launched: 26/09/2021
+- Company name (if applicable): None
+- Contact (email, Discord, etc.): josh_tharakan@hotmail.com, fomosapien.eth#9091
+- Kickback Rate: 100%
+- Product Description: A non-profit, reliable, and decentralized frontend for Liquity. Hosted on IPFS through Crust Network with over 120 replicas stored globally. 100% kickback rate.


### PR DESCRIPTION
## Liquity@Crust
- Website URL: https://ipfs.io/ipfs/QmUHwUh4zyahWknJaqGegaQzK76dL6pPTB1Fa2T1adpkEj/
- Date launched: 26/09/2021
- Company name (if applicable): None
- Contact (email, Discord, etc.): josh_tharakan@hotmail.com, fomosapien.eth#9091
- Kickback Rate: 100%
- Product Description: A non-profit, reliable, and decentralized frontend for Liquity. Hosted on IPFS through Crust Network with over 120 replicas stored globally. 100% kickback rate.