### PR TITLE
add web3QLiquity frontend

### DIFF
--- a/LIST.md
+++ b/LIST.md
@@ -4,6 +4,7 @@
 ## Frontend List
 | Name | Kickback Rate | 
 | ---- | ------------- | 
+| [Web3qLiquity](frontends/web3qLiquity.md) | 100% |
 | [Zerion](frontends/zerion.md) | 90% | 
 | [lusd.eth.link by 1kx](frontends/lusd.eth.link.md) | 95% | 
 | [LiquityFi](frontends/liquityfi.md) | 100% | 

--- a/frontends/web3qLiquity.md
+++ b/frontends/web3qLiquity.md
@@ -1,0 +1,8 @@
+## Web3q Liquity Frontend
+
+- Website URL: https://galileo.web3q.io/liquity.w3q/
+- Date launched: 03/29/2022 
+- Company name (if applicable): Web3q Protocol
+- Contact (email, Discord, etc.): hhhquickcreation@gmail.com
+- Kickback Rate: 100% 
+- Product Description:We implemented a completely decentralized Liquity front-end page through [Web3q Protocol](https://docs.web3q.io/). Web3q Liquity Frontend are stored on the blockchain and accessed through blockchain-based name services, similar to ENS. Users can borrow LUSD using ETH, stake LUSD in the stability pool to earn LQTY and ETH, and stake LQTY to earn ETH & LUSD. Main functionalities from Liquity are available. 


### PR DESCRIPTION
We implemented a completely decentralized Liquity front-end page through [Web3q Protocol](https://docs.web3q.io/). Web3q Liquity Frontend are stored on the blockchain and accessed through blockchain-based name services, similar to ENS.